### PR TITLE
ensure CS CLAIM channel exists, to be sure name is valid

### DIFF
--- a/projectns/cs_claim.c
+++ b/projectns/cs_claim.c
@@ -25,6 +25,13 @@ static void cmd_claim(sourceinfo_t *si, int parc, char *parv[])
 		return;
 	}
 
+	// make sure the channel exists
+	if (!channel_find(name))
+	{
+		command_fail(si, fault_nosuch_target, _("The channel \2%s\2 must exist in order to register it."), name);
+		return;
+	}
+
 	char *namespace = NULL;
 	struct projectns *p = projectsvs->channame_get_project(name, &namespace);
 


### PR DESCRIPTION
seems atheme uses "does the channel exist" as a means to know if the channel name is valid or not. could do with a better error message?