### PR TITLE
log group contacts being lost from a project being dropped

### DIFF
--- a/projectns/main/objects.c
+++ b/projectns/main/objects.c
@@ -76,6 +76,7 @@ void project_destroy(struct projectns * const p)
 	{
 		struct project_contact *contact = n->data;
 		contact_destroy(p, contact->mu);
+		slog(LG_REGISTER, _("PROJECT:CONTACT:LOST: \2%s\2 from \2%s\2"), entity(contact->mu)->name, contact->project->name);
 	}
 
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, p->channel_ns.head)


### PR DESCRIPTION
not 100% sure about this for 2 reasons

1. do we need this?
2. exact same wording as losing a GC from account drop:

https://github.com/edk0/atheme-extra/blob/0b65ba2ff6d325952d0eceac163af030d3780902/projectns/main/objects.c#L130

for 1, it makes [spinel](https://github.com/Libera-Chat/spinel)'s life significantly easier